### PR TITLE
#638 异常挂起后手工解挂2次，channel pipeline状态都显示正常，但实际上channel已经假死不同步。processId…

### DIFF
--- a/shared/arbitrate/src/main/java/com/alibaba/otter/shared/arbitrate/impl/setl/memory/ExtractMemoryArbitrateEvent.java
+++ b/shared/arbitrate/src/main/java/com/alibaba/otter/shared/arbitrate/impl/setl/memory/ExtractMemoryArbitrateEvent.java
@@ -52,6 +52,8 @@ public class ExtractMemoryArbitrateEvent implements ExtractArbitrateEvent {
         } else {
             logger.warn("pipelineId[{}] extract ignore processId[{}] by status[{}]", new Object[] { pipelineId,
                     processId, status });
+            // 释放下processId，因为MemoryStageController的load是等待processId最小值完成Tranform才继续，如果这里不释放，会一直卡死等待
+            stageController.clearProgress(processId);        
             return await(pipelineId);// 递归调用
         }
     }

--- a/shared/arbitrate/src/main/java/com/alibaba/otter/shared/arbitrate/impl/setl/memory/LoadMemoryArbitrateEvent.java
+++ b/shared/arbitrate/src/main/java/com/alibaba/otter/shared/arbitrate/impl/setl/memory/LoadMemoryArbitrateEvent.java
@@ -58,6 +58,8 @@ public class LoadMemoryArbitrateEvent implements LoadArbitrateEvent {
         } else {
             logger.warn("pipelineId[{}] load ignore processId[{}] by status[{}]", new Object[] { pipelineId, processId,
                     status });
+            // 释放下processId，因为MemoryStageController的load是等待processId最小值完成Tranform才继续，如果这里不释放，会一直卡死等待
+            stageController.clearProgress(processId);
             return await(pipelineId);// 递归调用
         }
     }

--- a/shared/arbitrate/src/main/java/com/alibaba/otter/shared/arbitrate/impl/setl/memory/TransformMemoryArbitrateEvent.java
+++ b/shared/arbitrate/src/main/java/com/alibaba/otter/shared/arbitrate/impl/setl/memory/TransformMemoryArbitrateEvent.java
@@ -52,6 +52,8 @@ public class TransformMemoryArbitrateEvent implements TransformArbitrateEvent {
         } else {
             logger.warn("pipelineId[{}] transform ignore processId[{}] by status[{}]", new Object[] { pipelineId,
                     processId, status });
+            // 释放下processId，因为MemoryStageController的load是等待processId最小值完成Tranform才继续，如果这里不释放，会一直卡死等待
+            stageController.clearProgress(processId);
             return await(pipelineId);// 递归调用
         }
     }

--- a/shared/arbitrate/src/main/java/com/alibaba/otter/shared/arbitrate/impl/setl/zookeeper/ExtractZooKeeperArbitrateEvent.java
+++ b/shared/arbitrate/src/main/java/com/alibaba/otter/shared/arbitrate/impl/setl/zookeeper/ExtractZooKeeperArbitrateEvent.java
@@ -103,6 +103,10 @@ public class ExtractZooKeeperArbitrateEvent implements ExtractArbitrateEvent {
         } else {
             logger.warn("pipelineId[{}] extract ignore processId[{}] by status[{}]", new Object[] { pipelineId,
                     processId, status });
+                    
+            // 释放下processId，因为load是等待processId最小值完成Tranform才继续，如果这里不释放，会一直卡死等待
+            String path = StagePathUtils.getProcess(pipelineId, processId);
+            zookeeper.delete(path);
             return await(pipelineId);// 递归调用
         }
 

--- a/shared/arbitrate/src/main/java/com/alibaba/otter/shared/arbitrate/impl/setl/zookeeper/LoadZooKeeperArbitrateEvent.java
+++ b/shared/arbitrate/src/main/java/com/alibaba/otter/shared/arbitrate/impl/setl/zookeeper/LoadZooKeeperArbitrateEvent.java
@@ -109,7 +109,9 @@ public class LoadZooKeeperArbitrateEvent implements LoadArbitrateEvent {
                 // } catch (KeeperException e) {
                 // // ignore
                 // }
-
+// 释放下processId，因为load是等待processId最小值完成Tranform才继续，如果这里不释放，会一直卡死等待
+            String path = StagePathUtils.getProcess(pipelineId, processId);
+            zookeeper.delete(path);
                 return await(pipelineId);// 出现rollback情况，递归调用重新获取一次，当前的processId可丢弃
             }
         } catch (InterruptedException e) {

--- a/shared/arbitrate/src/main/java/com/alibaba/otter/shared/arbitrate/impl/setl/zookeeper/TransformZooKeeperArbitrateEvent.java
+++ b/shared/arbitrate/src/main/java/com/alibaba/otter/shared/arbitrate/impl/setl/zookeeper/TransformZooKeeperArbitrateEvent.java
@@ -87,6 +87,10 @@ public class TransformZooKeeperArbitrateEvent implements TransformArbitrateEvent
         } else {
             logger.info("pipelineId[{}] transform ignore processId[{}] by status[{}]", new Object[] { pipelineId,
                     processId, status });
+                    
+            // 释放下processId，因为load是等待processId最小值完成Tranform才继续，如果这里不释放，会一直卡死等待
+            String path = StagePathUtils.getProcess(pipelineId, processId);
+            zookeeper.delete(path);
             return await(pipelineId);// 递归调用
         }
     }


### PR DESCRIPTION
当channel 变成PAUSE状态丢弃信号量时，应该从调度器里面把对应的processId 移除掉，防止后面的load操作因等待最小的processId变成Transform态出现卡死。