### PR TITLE
#623 #638 故障修复

### DIFF
--- a/node/etl/src/main/java/com/alibaba/otter/node/etl/select/SelectTask.java
+++ b/node/etl/src/main/java/com/alibaba/otter/node/etl/select/SelectTask.java
@@ -263,6 +263,9 @@ public class SelectTask extends GlobalTask {
                 if (rversion.get() != startVersion) {// 说明存在过变化，中间出现过rollback，需要丢弃该数据
                     logger.warn("rollback happend , should skip this data and get new message.");
                     canStartSelector.get();// 确认一下rollback是否完成
+                    // 先睡眠一段时间，保证channel有足够的时间变成pause态，即使没有变成PAUSE态，***MemoryArbitrateEvent里面有回滚操作兜底。
+                    Thread.sleep(10 * 1000);
+                    arbitrateEventService.toolEvent().waitForPermit(pipelineId);
                     gotMessage = otterSelector.selector();// 这时不管有没有数据，都需要执行一次s/e/t/l
                 }
 

--- a/shared/arbitrate/src/main/java/com/alibaba/otter/shared/arbitrate/impl/setl/memory/LoadMemoryArbitrateEvent.java
+++ b/shared/arbitrate/src/main/java/com/alibaba/otter/shared/arbitrate/impl/setl/memory/LoadMemoryArbitrateEvent.java
@@ -56,10 +56,13 @@ public class LoadMemoryArbitrateEvent implements LoadArbitrateEvent {
         if (status.isStart()) {// 即时查询一下当前的状态，状态随时可能会变
             return stageController.getLastData(processId);
         } else {
-            logger.warn("pipelineId[{}] load ignore processId[{}] by status[{}]", new Object[] { pipelineId, processId,
+            logger.warn("pipelineId[{}] load ignore processId[{}] by status[{}],rollback now",
+                new Object[] { pipelineId, processId,
                     status });
-            // 释放下processId，因为MemoryStageController的load是等待processId最小值完成Tranform才继续，如果这里不释放，会一直卡死等待
-            stageController.clearProgress(processId);
+            // 进行ROLLBACK，触发释放下processId，信号量及EventStore里面的读位置点。
+            // 1)因为MemoryStageController的load是等待processId最小值完成Tranform才继续，如果这里不释放，会一直卡死等待
+            // 2)信号量消耗完selectTask任务停止，3)EventStore里面的读位置点不回置，如果正好队列已经满并且读取了最后，BINLOG新的数据进不来
+            stageController.termin(TerminType.ROLLBACK);
             return await(pipelineId);// 递归调用
         }
     }

--- a/shared/arbitrate/src/main/java/com/alibaba/otter/shared/arbitrate/impl/setl/memory/TransformMemoryArbitrateEvent.java
+++ b/shared/arbitrate/src/main/java/com/alibaba/otter/shared/arbitrate/impl/setl/memory/TransformMemoryArbitrateEvent.java
@@ -24,6 +24,7 @@ import com.alibaba.otter.shared.arbitrate.impl.setl.ArbitrateFactory;
 import com.alibaba.otter.shared.arbitrate.impl.setl.TransformArbitrateEvent;
 import com.alibaba.otter.shared.arbitrate.impl.setl.monitor.PermitMonitor;
 import com.alibaba.otter.shared.arbitrate.model.EtlEventData;
+import com.alibaba.otter.shared.arbitrate.model.TerminEventData.TerminType;
 import com.alibaba.otter.shared.common.model.config.channel.ChannelStatus;
 import com.alibaba.otter.shared.common.model.config.enums.StageType;
 
@@ -50,10 +51,13 @@ public class TransformMemoryArbitrateEvent implements TransformArbitrateEvent {
         if (status.isStart()) {// 即时查询一下当前的状态，状态随时可能会变
             return stageController.getLastData(processId);
         } else {
-            logger.warn("pipelineId[{}] transform ignore processId[{}] by status[{}]", new Object[] { pipelineId,
+            logger.warn("pipelineId[{}] transform ignore processId[{}] by status[{}],rollback now",
+                new Object[] { pipelineId,
                     processId, status });
-            // 释放下processId，因为MemoryStageController的load是等待processId最小值完成Tranform才继续，如果这里不释放，会一直卡死等待
-            stageController.clearProgress(processId);
+            // 进行ROLLBACK，触发释放下processId，信号量及EventStore里面的读位置点。
+            // 1)因为MemoryStageController的load是等待processId最小值完成Tranform才继续，如果这里不释放，会一直卡死等待
+            // 2)信号量消耗完selectTask任务停止3)EventStore里面的读位置点不回置，如果正好队列已经满并且读取了最后，BINLOG新的数据进不来
+            stageController.termin(TerminType.ROLLBACK);
             return await(pipelineId);// 递归调用
         }
     }


### PR DESCRIPTION
#623 监控报canal elapsed XXX seconds no data

#638 异常挂起后手工解挂2次，channel pipeline状态都显示正常，但实际上channel已经假死不同步
----之前提交的removeProcessId()在pipeline并发度为1的情况下还会稳定出现卡死问题，改成彻底的rollback以重置processId,select stage信号，eventStore读位置点。 另外在SelectTask里面加sleep和wait channel变成start态，以尽量避免后面发现channel为pause态而放弃处理这段逻辑。