### PR TITLE
[fixed issue #694 otter 同步 RDS 到 DRDS 出现拆分键无法更新问题]

### DIFF
--- a/node/etl/src/main/java/com/alibaba/otter/node/etl/common/db/dialect/SqlTemplate.java
+++ b/node/etl/src/main/java/com/alibaba/otter/node/etl/common/db/dialect/SqlTemplate.java
@@ -26,7 +26,7 @@ public interface SqlTemplate {
 
     public String getSelectSql(String schemaName, String tableName, String[] pkNames, String[] columnNames);
 
-    public String getUpdateSql(String schemaName, String tableName, String[] pkNames, String[] columnNames);
+    public String getUpdateSql(String schemaName, String tableName, String[] pkNames, String[] columnNames, boolean updatePks, String shardColumn);
 
     public String getDeleteSql(String schemaName, String tableName, String[] pkNames);
 
@@ -36,5 +36,5 @@ public interface SqlTemplate {
      * 获取对应的mergeSql
      */
     public String getMergeSql(String schemaName, String tableName, String[] pkNames, String[] columnNames,
-                              String[] viewColumnNames, boolean updatePks);
+                              String[] viewColumnNames, boolean updatePks, String shardColumn);
 }

--- a/node/etl/src/main/java/com/alibaba/otter/node/etl/common/db/dialect/mysql/MysqlSqlTemplate.java
+++ b/node/etl/src/main/java/com/alibaba/otter/node/etl/common/db/dialect/mysql/MysqlSqlTemplate.java
@@ -29,7 +29,7 @@ public class MysqlSqlTemplate extends AbstractSqlTemplate {
     private static final String ESCAPE = "`";
 
     public String getMergeSql(String schemaName, String tableName, String[] pkNames, String[] columnNames,
-                              String[] viewColumnNames, boolean includePks) {
+                              String[] viewColumnNames, boolean includePks, String shardColumn) {
         StringBuilder sql = new StringBuilder("insert into " + getFullName(schemaName, tableName) + "(");
         int size = columnNames.length;
         for (int i = 0; i < size; i++) {
@@ -54,6 +54,11 @@ public class MysqlSqlTemplate extends AbstractSqlTemplate {
 
         size = columnNames.length;
         for (int i = 0; i < size; i++) {
+            // 如果是DRDS数据库, 并且存在拆分键 且 等于当前循环列, 跳过
+            if(!includePks && shardColumn != null && columnNames[i].equals(shardColumn)){
+                continue;
+            }
+
             sql.append(appendEscape(columnNames[i]))
                 .append("=values(")
                 .append(appendEscape(columnNames[i]))

--- a/node/etl/src/main/java/com/alibaba/otter/node/etl/common/db/dialect/oracle/OracleSqlTemplate.java
+++ b/node/etl/src/main/java/com/alibaba/otter/node/etl/common/db/dialect/oracle/OracleSqlTemplate.java
@@ -32,7 +32,7 @@ public class OracleSqlTemplate extends AbstractSqlTemplate {
      * http://en.wikipedia.org/wiki/Merge_(SQL)
      */
     public String getMergeSql(String schemaName, String tableName, String[] keyNames, String[] columnNames,
-                              String[] viewColumnNames, boolean includePks) {
+                              String[] viewColumnNames, boolean includePks, String shardColumn) {
         final String aliasA = "a";
         final String aliasB = "b";
         StringBuilder sql = new StringBuilder();

--- a/node/etl/src/test/java/com/alibaba/otter/node/etl/common/db/DbDialectTest.java
+++ b/node/etl/src/test/java/com/alibaba/otter/node/etl/common/db/DbDialectTest.java
@@ -16,12 +16,14 @@
 
 package com.alibaba.otter.node.etl.common.db;
 
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.sql.Types;
-import java.util.ArrayList;
-import java.util.List;
-
+import com.alibaba.otter.node.etl.BaseDbTest;
+import com.alibaba.otter.node.etl.common.db.dialect.DbDialect;
+import com.alibaba.otter.node.etl.common.db.dialect.DbDialectFactory;
+import com.alibaba.otter.node.etl.common.db.dialect.SqlTemplate;
+import com.alibaba.otter.node.etl.common.db.dialect.mysql.MysqlDialect;
+import com.alibaba.otter.node.etl.common.db.dialect.oracle.OracleDialect;
+import com.alibaba.otter.node.etl.common.db.utils.SqlUtils;
+import com.alibaba.otter.shared.common.model.config.data.db.DbDataMedia;
 import org.jtester.annotations.SpringBeanByName;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -33,14 +35,11 @@ import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.testng.annotations.Test;
 
-import com.alibaba.otter.node.etl.BaseDbTest;
-import com.alibaba.otter.node.etl.common.db.dialect.DbDialect;
-import com.alibaba.otter.node.etl.common.db.dialect.DbDialectFactory;
-import com.alibaba.otter.node.etl.common.db.dialect.SqlTemplate;
-import com.alibaba.otter.node.etl.common.db.dialect.mysql.MysqlDialect;
-import com.alibaba.otter.node.etl.common.db.dialect.oracle.OracleDialect;
-import com.alibaba.otter.node.etl.common.db.utils.SqlUtils;
-import com.alibaba.otter.shared.common.model.config.data.db.DbDataMedia;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
 
 public class DbDialectTest extends BaseDbTest {
 
@@ -96,7 +95,7 @@ public class DbDialectTest extends BaseDbTest {
                 });
                 want.number(affect).isEqualTo(1);
                 // 执行update
-                sql = sqlTemplate.getUpdateSql(MYSQL_SCHEMA_NAME, TABLE_NAME, pkColumns, columns);
+                sql = sqlTemplate.getUpdateSql(MYSQL_SCHEMA_NAME, TABLE_NAME, pkColumns, columns, true, null);
                 System.out.println(sql);
                 affect = (Integer) jdbcTemplate.execute(sql, new PreparedStatementCallback() {
 
@@ -123,7 +122,7 @@ public class DbDialectTest extends BaseDbTest {
                 });
                 want.number(affect).isEqualTo(1);
                 // 执行merge
-                sql = sqlTemplate.getMergeSql(MYSQL_SCHEMA_NAME, TABLE_NAME, pkColumns, columns, null, true);
+                sql = sqlTemplate.getMergeSql(MYSQL_SCHEMA_NAME, TABLE_NAME, pkColumns, columns, null, true, null);
                 System.out.println(sql);
                 affect = (Integer) jdbcTemplate.execute(sql, new PreparedStatementCallback() {
 
@@ -176,7 +175,7 @@ public class DbDialectTest extends BaseDbTest {
                 });
                 want.number(affect).isEqualTo(1);
                 // 执行update
-                sql = sqlTemplate.getUpdateSql(ORACLE_SCHEMA_NAME, TABLE_NAME, pkColumns, columns);
+                sql = sqlTemplate.getUpdateSql(ORACLE_SCHEMA_NAME, TABLE_NAME, pkColumns, columns, true, null);
                 System.out.println(sql);
                 affect = (Integer) jdbcTemplate.execute(sql, new PreparedStatementCallback() {
 
@@ -203,7 +202,7 @@ public class DbDialectTest extends BaseDbTest {
                 });
                 want.number(affect).isEqualTo(1);
                 // 执行merge
-                sql = sqlTemplate.getMergeSql(ORACLE_SCHEMA_NAME, TABLE_NAME, pkColumns, columns, null, true);
+                sql = sqlTemplate.getMergeSql(ORACLE_SCHEMA_NAME, TABLE_NAME, pkColumns, columns, null, true, null);
                 System.out.println(sql);
 
                 affect = (Integer) jdbcTemplate.execute(sql, new PreparedStatementCallback() {

--- a/node/etl/src/test/java/com/alibaba/otter/node/etl/common/db/SqlTemplateTest.java
+++ b/node/etl/src/test/java/com/alibaba/otter/node/etl/common/db/SqlTemplateTest.java
@@ -40,16 +40,16 @@ public class SqlTemplateTest extends BaseDbTest {
         String sql2 = sqlTemplate.getInsertSql(SCHEMA_NAME, TABLE_NAME, pkColumns, columns);
         want.bool(sql1 == sql2);
         // 执行update
-        sql1 = sqlTemplate.getUpdateSql(SCHEMA_NAME, TABLE_NAME, pkColumns, columns);
-        sql2 = sqlTemplate.getUpdateSql(SCHEMA_NAME, TABLE_NAME, pkColumns, columns);
+        sql1 = sqlTemplate.getUpdateSql(SCHEMA_NAME, TABLE_NAME, pkColumns, columns, true, null);
+        sql2 = sqlTemplate.getUpdateSql(SCHEMA_NAME, TABLE_NAME, pkColumns, columns, true, null);
         want.bool(sql1 == sql2);
         // 执行deleate
         sql1 = sqlTemplate.getDeleteSql(SCHEMA_NAME, TABLE_NAME, pkColumns);
         sql2 = sqlTemplate.getDeleteSql(SCHEMA_NAME, TABLE_NAME, pkColumns);
         want.bool(sql1 == sql2);
         // 执行merge
-        sql1 = sqlTemplate.getMergeSql(SCHEMA_NAME, TABLE_NAME, pkColumns, columns, null, true);
-        sql2 = sqlTemplate.getMergeSql(SCHEMA_NAME, TABLE_NAME, pkColumns, columns, null, true);
+        sql1 = sqlTemplate.getMergeSql(SCHEMA_NAME, TABLE_NAME, pkColumns, columns, null, true, null);
+        sql2 = sqlTemplate.getMergeSql(SCHEMA_NAME, TABLE_NAME, pkColumns, columns, null, true, null);
         want.bool(sql1 == sql2);
 
     }
@@ -62,16 +62,16 @@ public class SqlTemplateTest extends BaseDbTest {
         String sql2 = sqlTemplate.getInsertSql(SCHEMA_NAME, TABLE_NAME, pkColumns, columns);
         want.bool(sql1 == sql2);
         // 执行update
-        sql1 = sqlTemplate.getUpdateSql(SCHEMA_NAME, TABLE_NAME, pkColumns, columns);
-        sql2 = sqlTemplate.getUpdateSql(SCHEMA_NAME, TABLE_NAME, pkColumns, columns);
+        sql1 = sqlTemplate.getUpdateSql(SCHEMA_NAME, TABLE_NAME, pkColumns, columns, true, null);
+        sql2 = sqlTemplate.getUpdateSql(SCHEMA_NAME, TABLE_NAME, pkColumns, columns, true, null);
         want.bool(sql1 == sql2);
         // 执行deleate
         sql1 = sqlTemplate.getDeleteSql(SCHEMA_NAME, TABLE_NAME, pkColumns);
         sql2 = sqlTemplate.getDeleteSql(SCHEMA_NAME, TABLE_NAME, pkColumns);
         want.bool(sql1 == sql2);
         // 执行merge
-        sql1 = sqlTemplate.getMergeSql(SCHEMA_NAME, TABLE_NAME, pkColumns, columns, null, true);
-        sql2 = sqlTemplate.getMergeSql(SCHEMA_NAME, TABLE_NAME, pkColumns, columns, null, true);
+        sql1 = sqlTemplate.getMergeSql(SCHEMA_NAME, TABLE_NAME, pkColumns, columns, null, true, null);
+        sql2 = sqlTemplate.getMergeSql(SCHEMA_NAME, TABLE_NAME, pkColumns, columns, null, true, null);
         want.bool(sql1 == sql2);
     }
 


### PR DESCRIPTION
在 Load 阶段， SqlBuilderLoadInterceptor merge处理的时候，针对 update 和 insert on duplicate key update 时，针对set 字段列表中，去除 拆分键 的 sql语句拼接