### PR TITLE
Pipeline 支持配置 Load 事务大小

### DIFF
--- a/manager/deployer/src/main/resources/webapp/WEB-INF/home/form.xml
+++ b/manager/deployer/src/main/resources/webapp/WEB-INF/home/form.xml
@@ -209,6 +209,17 @@
 					<message>${displayName} 必须是大于0的整数</message>
 				</fm-validators:number-validator>
 			</field>
+			<field name="loadBatchsize" displayName="Load批次大小">
+				<fm-validators:required-validator>
+					<message>必须填写${displayName}</message>
+				</fm-validators:required-validator>
+				<fm-validators:number-validator>
+					<message>${displayName} 必须是数字且是整数</message>
+				</fm-validators:number-validator>
+				<fm-validators:number-validator greaterThan="0">
+					<message>${displayName} 必须是大于0的整数</message>
+				</fm-validators:number-validator>
+			</field>
 			<field name="channelInfo" displayName="同步标记" />
 			<field name="dryRun" displayName="DryRun模式" />
 			<field name="ddlSync" displayName="支持ddl同步" />

--- a/manager/deployer/src/main/resources/webapp/templates/home/screen/addPipeline.vm
+++ b/manager/deployer/src/main/resources/webapp/templates/home/screen/addPipeline.vm
@@ -179,6 +179,14 @@ $control.setTemplate("home:navigation.vm")
 			  <span class="red">#addPipelineMessage ($pipelineParameterGroup.batchTimeout)</span>
         </td>
       </tr>
+	  <tr> 
+        <th width="300">Load批次大小：</th>
+        <td width="329">
+              <input name="$pipelineParameterGroup.loadBatchsize.key" value="50" type="text" class="setting_input"/><span class="red">*</span>
+			  <br />
+			  <span class="red">#addPipelineMessage ($pipelineParameterGroup.loadBatchsize)</span>
+        </td>
+      </tr>
 	  <tr>
        <th>描述：</th>
        <td>

--- a/manager/deployer/src/main/resources/webapp/templates/home/screen/editPipeline.vm
+++ b/manager/deployer/src/main/resources/webapp/templates/home/screen/editPipeline.vm
@@ -192,6 +192,14 @@ $control.setTemplate("home:navigation.vm")
 			  <span class="red">#editPipelineMessage ($pipelineParameterGroup.batchTimeout)</span>
         </td>
       </tr>
+	  <tr> 
+        <th width="300">Load批次大小：</th>
+        <td width="329">
+              <input name="$pipelineParameterGroup.loadBatchsize.key" value="$pipeline.parameters.loadBatchsize" type="text" class="setting_input"/><span class="red">*</span>
+			  <br />
+			  <span class="red">#editPipelineMessage ($pipelineParameterGroup.loadBatchsize)</span>
+        </td>
+      </tr>
       <tr>
        <th>描述：</th>
        <td>

--- a/manager/deployer/src/main/resources/webapp/templates/home/screen/pipelineInfo.vm
+++ b/manager/deployer/src/main/resources/webapp/templates/home/screen/pipelineInfo.vm
@@ -70,6 +70,9 @@ $control.setTemplate("home:navigation.vm")
 	</tr>
   #end
   <tr>
+  <th>Load批次大小：</th><td>$!pipeline.parameters.loadBatchsize</td>
+  </tr>
+  <tr>
   <th>描述信息：</th><td>$!pipeline.description</td>
   </tr>
   

--- a/node/etl/src/main/java/com/alibaba/otter/node/etl/load/loader/db/DbLoadAction.java
+++ b/node/etl/src/main/java/com/alibaba/otter/node/etl/load/loader/db/DbLoadAction.java
@@ -494,6 +494,12 @@ public class DbLoadAction implements InitializingBean, DisposableBean {
     private void adjustConfig(DbLoadContext context) {
         Pipeline pipeline = context.getPipeline();
         this.useBatch = pipeline.getParameters().isUseBatch();
+
+        // 旧版本manager配置序列化传输时可能无此配置项，因此只有专门配置过的，才进行调整
+        Integer loadBatchsize = pipeline.getParameters().getLoadBatchsize();
+        if (loadBatchsize != null && loadBatchsize > 0){
+            this.batchSize = loadBatchsize;
+        }
     }
 
     public void afterPropertiesSet() throws Exception {

--- a/shared/common/src/main/java/com/alibaba/otter/shared/common/model/config/pipeline/PipelineParameter.java
+++ b/shared/common/src/main/java/com/alibaba/otter/shared/common/model/config/pipeline/PipelineParameter.java
@@ -49,6 +49,7 @@ public class PipelineParameter implements Serializable {
     private String                destinationName;
     private Short                 mainstemClientId;                                         // mainstem订阅id
     private Integer               mainstemBatchsize          = 10000 * 10;                  // mainstem订阅批次大小
+    private Integer               loadBatchsize              = 50;                          // load批次大小
     private Integer               extractPoolSize            = 5;                           // extract模块载入线程数，针对单个载入通道
     private Integer               loadPoolSize               = 5;                           // load模块载入线程数，针对单个载入通道
     private Integer               fileLoadPoolSize           = 5;                           // 文件同步线程数
@@ -273,6 +274,14 @@ public class PipelineParameter implements Serializable {
 
     public Integer getMainstemBatchsize() {
         return mainstemBatchsize;
+    }
+
+    public Integer getLoadBatchsize() {
+        return loadBatchsize;
+    }
+
+    public void setLoadBatchsize(Integer loadBatchsize) {
+        this.loadBatchsize = loadBatchsize;
     }
 
     public Boolean isHome() {


### PR DESCRIPTION
## 功能介绍

为了调节 Load 阶段每次写入目标库的事务大小，支持在 otter manager 配置 otter node 的 `com.alibaba.otter.node.etl.load.loader.db.DbLoadAction.batchSize` 参数：

https://github.com/alibaba/otter/blob/7f80d17d74e5bf1b2c092b61abd6a3a13eed43f3/node/etl/src/main/java/com/alibaba/otter/node/etl/load/loader/db/DbLoadAction.java#L103

manager 界面举例：

*添加 pipeline*
![添加 pipeline](https://user-images.githubusercontent.com/6769630/68111286-bb24bd80-ff29-11e9-8eeb-a54504f86df6.png)

*查看 pipeline 信息*
![查看 pipeline 信息](https://user-images.githubusercontent.com/6769630/68111317-d099e780-ff29-11e9-9b4f-3e6156ddc79d.png)

## 背景

业务场景为有一张存在突发大量写入（INSERT、DELETE）的表需要通过 otter 进行同步，观察到突发大量写入（3000+ 行/秒）时，同步出现延迟

观察 select 日志和 load 日志，发现：

+ select 消费到批次 -> load 完成写入之间时间间隔较长
+ load 完成写入 -> 下一次 select 消费到批次几乎为瞬时

由于 pipeline 在 E.、T. 阶段没有配置字段转换等规则，推测为 L. 阶段目标库写入存在瓶颈

查看目标库表设计，存在较多索引，同时发现 `com.alibaba.otter.node.etl.load.loader.db.DbLoadAction.batchSize` 为写死的 `50`（即 Load 阶段一个事务最多写入 50 条数据），因此怀疑目标库频繁的写入事务重建索引等操作降低了写入的吞吐量，将此数值调大后，发现吞吐量有较大提升

**修改前**

batchSize = 50，同步出现延迟（代表 Load 打满）时，吞吐量约为 60,000 行/分钟

*batchSize-50-吞吐*
![batchSize-50-吞吐](https://user-images.githubusercontent.com/6769630/68114128-40ab6c00-ff30-11e9-8edb-2812eb303d4a.png)

*batchSize-50-延迟*
![batchSize-50-延迟](https://user-images.githubusercontent.com/6769630/68114108-35584080-ff30-11e9-8f89-4cd3dc914c85.png)

**修改后**

batchSize = 10000，同时调大了消费批次大小以确保每个 batch 行数足够满足每个事务。同步出现延迟时，吞吐量约为 350,000 行/分钟；吞吐量为 88,000 行/分钟 时，没有出现延迟

*batchSize-10000-吞吐*
![batchSize-10000-吞吐](https://user-images.githubusercontent.com/6769630/68114371-d34c0b00-ff30-11e9-82f2-76c533301f3e.png)

*batchSize-10000-延迟*
![batchSize-10000-延迟](https://user-images.githubusercontent.com/6769630/68114350-c7604900-ff30-11e9-9239-356b80ae601a.png)

## 建议配置

如果用户遇到的问题及目标库结构类似，可以进行相似调整，注意以下几点：

+ pipeline 消费批次调大时，需要确保 batch 行数足够，例如 Load 批次大小 10000，消费批次为接近 10000 的整数倍为宜；或者直接将 Load 批次调很大，这样完全以消费的每个 batch 大小作为事务大小，一个 batch 操作正好一个事务
+ 如果 Load 批次大小以及写入并发数配置过大，可能会导致目标库事务执行超时 Load 失败，因此还是需要结合目标库实际的事务执行能力进行评估。在调大 Load 批次大小的同时，可以适当调小写入并发数