### PR TITLE
delete parent to avoid compiling fail

### DIFF
--- a/lib/jmockit-0.999.10.pom
+++ b/lib/jmockit-0.999.10.pom
@@ -3,7 +3,7 @@
    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <modelVersion>4.0.0</modelVersion>
 
-   <parent><groupId>mockit</groupId><artifactId>mockit</artifactId><version>0.999.10</version></parent>
+   <groupId>mockit</groupId>
    <artifactId>jmockit</artifactId><version>0.999.10</version>
    <name>Main</name>
 


### PR DESCRIPTION
Could not transfer artifact mockit:mockit:pom:0.999.10

[ERROR] Failed to execute goal on project shared.common: Could not resolve dependencies for project com.alibaba.otter:shared.common:jar:4.2.19-SNAPSHOT: Failed to collect dependencies at org.jtester:jtester:jar:1.1.8 -> mockit:jmockit:jar:0.999.10: Failed to read artifact descriptor for mockit:jmockit:jar:0.999.10: Could not transfer artifact mockit:mockit:pom:0.999.10 from/to central (http://repo1.maven.org/maven2): Failed to transfer file: http://repo1.maven.org/maven2/mockit/mockit/0.999.10/mockit-0.999.10.pom. Return code is: 501 , ReasonPhrase:HTTPS Required. -> [Help 1]