### PR TITLE
Update jmockit-0.999.10.pom

### DIFF
--- a/lib/jmockit-0.999.10.pom
+++ b/lib/jmockit-0.999.10.pom
@@ -3,7 +3,7 @@
    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <modelVersion>4.0.0</modelVersion>
 
-   <parent><groupId>mockit</groupId><artifactId>mockit</artifactId><version>0.999.10</version></parent>
+<!--   <parent><groupId>mockit</groupId><artifactId>mockit</artifactId><version>0.999.10</version></parent>-->
    <artifactId>jmockit</artifactId><version>0.999.10</version>
    <name>Main</name>
 


### PR DESCRIPTION
[ERROR] Failed to execute goal on project shared.common: Could not resolve dependencies for project com.alibaba.otter:shared.common:jar:4.2.19-SNAPSHOT: Failed to collect dependencies at org.jtester:jtester:jar:1.1.8: Failed to read artifact descriptor for org.jtester:jtester:jar:1.1.8: Could not transfer artifact org.jtester:jtester:pom:1.1.8 from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [java.net (http://download.java.net/maven/2/, default, releases), jtester-maven (http://jtester.googlecode.com/svn/m2/, default, releases)] ->
编译问题