### PR TITLE
fix(sec): upgrade org.directwebremoting:dwr to 3.0.RC3

### DIFF
--- a/manager/pom.xml
+++ b/manager/pom.xml
@@ -76,7 +76,7 @@
 			<dependency>
 				<groupId>org.directwebremoting</groupId>
 				<artifactId>dwr</artifactId>
-				<version>2.0.10</version>
+				<version>3.0.RC3</version>
 			</dependency>
 			<!-- jetty -->
 			<dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.directwebremoting:dwr 2.0.10
- [CVE-2014-5325](https://www.oscs1024.com/hd/CVE-2014-5325)


### What did I do？
Upgrade org.directwebremoting:dwr from 2.0.10 to 3.0.RC3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS