### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-http to 11.0.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<file_encoding>UTF-8</file_encoding>
 		<spring-version>3.1.2.RELEASE</spring-version>
-		<jetty_verion>8.1.7.v20120910</jetty_verion>
+		<jetty_verion>11.0.10</jetty_verion>
 		<logback_version>1.2.9</logback_version>
 		<slf4j_version>1.7.12</slf4j_version>
 		<otter_canal_version>1.1.5</otter_canal_version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty:jetty-http 8.1.7.v20120910
- [CVE-2022-2047](https://www.oscs1024.com/hd/CVE-2022-2047)


### What did I do？
Upgrade org.eclipse.jetty:jetty-http from 8.1.7.v20120910 to 11.0.10 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS