### PR TITLE
fix(sec): upgrade com.google.protobuf:protobuf-java to 3.21.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
 			<dependency>
 				<groupId>com.google.protobuf</groupId>
 				<artifactId>protobuf-java</artifactId>
-				<version>3.16.1</version>
+				<version>3.21.7</version>
 			</dependency>
             <dependency>
                 <groupId>com.alibaba</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.protobuf:protobuf-java 3.16.1
- [CVE-2022-3171](https://www.oscs1024.com/hd/CVE-2022-3171)


### What did I do？
Upgrade com.google.protobuf:protobuf-java from 3.16.1 to 3.21.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>