### PR TITLE
处理 Druid 版本导致的 MySQL 同步期间 java.lang.NoSuchFieldError: MYSQL

### DIFF
--- a/node/etl/src/main/java/com/alibaba/otter/node/etl/common/db/utils/DdlUtils.java
+++ b/node/etl/src/main/java/com/alibaba/otter/node/etl/common/db/utils/DdlUtils.java
@@ -12,6 +12,7 @@ import com.alibaba.druid.sql.ast.statement.SQLAlterTableItem;
 import com.alibaba.druid.sql.ast.statement.SQLAlterTableStatement;
 import com.alibaba.druid.sql.ast.statement.SQLCreateTableStatement;
 import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
+import com.alibaba.druid.sql.ast.statement.SQLAssignItem;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlCreateTableStatement;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlRenameTableStatement;
 import com.alibaba.druid.sql.dialect.mysql.parser.MySqlStatementParser;
@@ -127,7 +128,7 @@ public class DdlUtils {
                 print0(ucase ? "TABLE " : "table ");
             }
 
-            if (x.isIfNotExiists()) {
+            if (x.isIfNotExists()) {
                 print0(ucase ? "IF NOT EXISTS " : "if not exists ");
             }
 
@@ -155,8 +156,8 @@ public class DdlUtils {
                 print(')');
             }
 
-            for (Map.Entry<String, SQLObject> option : x.getTableOptions().entrySet()) {
-                String key = option.getKey();
+            for (SQLAssignItem option : x.getTableOptions()) {
+                String key = ((SQLIdentifierExpr) option.getTarget()).getName();
 
                 print(' ');
                 print0(ucase ? key : key.toLowerCase());
@@ -236,8 +237,8 @@ public class DdlUtils {
             decrementIndent();
 
             int i = 0;
-            for (Map.Entry<String, SQLObject> option : x.getTableOptions().entrySet()) {
-                String key = option.getKey();
+            for (SQLAssignItem option : x.getTableOptions()) {
+                String key = ((SQLIdentifierExpr) option.getTarget()).getName();
                 if (i != 0) {
                     print(' ');
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
             <dependency>
                 <groupId>com.alibaba</groupId>
                 <artifactId>druid</artifactId>
-                <version>1.1.9</version>
+                <version>1.2.6</version>
             </dependency>
             <dependency>
                 <groupId>com.alibaba.fastsql</groupId>


### PR DESCRIPTION
异常现象：MySQL数据同步过程中，pipeline 同步停止，延迟时间不断增大
日志显示：java.lang.NoSuchFieldError: MYSQL
修复手段：修改 Druid 版本和相关代码
#1068 